### PR TITLE
排版及细节校正

### DIFF
--- a/Backward-incompatible-changes.md
+++ b/Backward-incompatible-changes.md
@@ -11,7 +11,7 @@ PHP7 中详细的 Error 信息可以参考 [PHP7 错误](http://php.net/manual/e
 现在，解析 [eval\(\)](http://php.net/manual/en/function.eval.php) 错误会抛出一个 [解析异常](http://php.net/manual/en/class.parseerror.php) 对象。其可以通过 [catch](http://php.net/manual/en/language.exceptions.php#language.exceptions.catch) 捕捉，并做相应处理。
 
 #### E_STRICT 等级的报错被重新分配
-所有**E_STRICT**级别的报错已重新分配到其他报错等级中。**E_STRICT** 常量依然保留，所以当你设置报错等级为 **error_reporting\(E_ALL|E_STRICT\)** 时，不会引起报错。<br>
+所有 **E_STRICT** 级别的报错已重新分配到其他报错等级中。**E_STRICT** 常量依然保留，所以当你设置报错等级为 **error_reporting\(E_ALL|E_STRICT\)** 时，不会引起报错。<br>
 变更情况如下表
 ![image](https://cloud.githubusercontent.com/assets/1308846/9434941/01402560-4a76-11e5-9943-f9f153745030.png)
 
@@ -176,11 +176,11 @@ foreach ($array as &$val) {
 }
 ?>
 ```
-在PHP5 的输出为：
+在 PHP5 的输出为：
 ```PHP
 int(0)
 ```
-在PHP7 的输出为：
+在 PHP7 的输出为：
 ```PHP
 int(0)
 int(1)

--- a/Backward-incompatible-changes.md
+++ b/Backward-incompatible-changes.md
@@ -1,22 +1,22 @@
 # PHP5.6.x版本迁移至7.0.x版本
 ## 向后兼容说明
 ### 错误和异常处理的变更
-许多可以被修正的Fatal错误，在PHP7中将以Exceptions异常的形式抛出。这些Error Exceptions继承于 [Error](http://php.net/manual/en/class.error.php) 类。而 [Error](http://php.net/manual/en/class.error.php) 类则实现了异常基类 [Throwable](http://php.net/manual/en/class.throwable.php) 接口。 <br>
+许多可以被修正的 Fatal 错误，在 PHP7 中将以 Exceptions 异常的形式抛出。这些 Error Exceptions 继承于 [Error](http://php.net/manual/en/class.error.php) 类。而 [Error](http://php.net/manual/en/class.error.php) 类则实现了异常基类 [Throwable](http://php.net/manual/en/class.throwable.php) 接口。 <br>
 PHP7中详细的Error信息可以参考\[ [PHP7错误](http://php.net/manual/en/language.errors.php7.php) \]。本文中仅仅介绍和向后兼容有关的信息如下。
 
 #### 类构造函数在失败时抛出异常
-之前，类构造函数在失败时总是返回NULL或者返回一个不可用的Object，但从PHP7开始，在构造函数初始化失败时会抛出[异常](http://php.net/manual/en/class.exception.php)。
+之前，类构造函数在失败时总是返回NULL或者返回一个不可用的 Object，但从 PHP7 开始，在构造函数初始化失败时会抛出[异常](http://php.net/manual/en/class.exception.php)。
 
 #### 解析错误时会抛出 [解析异常](http://php.net/manual/en/class.parseerror.php)
 现在，解析[eval\(\)]错误会抛出一个 [解析异常](http://php.net/manual/en/class.parseerror.php) 对象。其可以通过 [catch](http://php.net/manual/en/language.exceptions.php#language.exceptions.catch) 捕捉，并做相应处理。
 
 #### E_STRICT 等级的报错被重新分配
-所有**E_STRICT**级别的报错已重新分配到其他报错等级中。**E_STRICT**常量依然保留，所以当你设置报错等级为 **error_reporting\(E_ALL|E_STRICT\)**时，不会引起报错。<br>
+所有**E_STRICT**级别的报错已重新分配到其他报错等级中。**E_STRICT** 常量依然保留，所以当你设置报错等级为 **error_reporting\(E_ALL|E_STRICT\)** 时，不会引起报错。<br>
 变更情况如下表
 ![image](https://cloud.githubusercontent.com/assets/1308846/9434941/01402560-4a76-11e5-9943-f9f153745030.png)
 
 ### 变量处理环节的变更
-由于PHP7采用抽象的语法树解析代码文件，并且过去的PHP版本无法满足该特性，这一变化将引起一些一致性问题。本节详细介绍这块的情况。
+由于 PHP7 采用抽象的语法树解析代码文件，并且过去的 PHP 版本无法满足该特性，这一变化将引起一些一致性问题。本节详细介绍这块的情况。
 
 #### 对于间接变量、属性、方法的变动
 间接的使用变量、属性、方法，将严格按照从左到右的顺序执行，而不会因形式问题导致歧义。下表将表明的这一改变引起的差异。
@@ -25,14 +25,14 @@ PHP7中详细的Error信息可以参考\[ [PHP7错误](http://php.net/manual/en/
 
 #### 对于 [list\(\)](http://php.net/manual/en/function.list.php) 函数处理上的修改
 ##### [list\(\)](http://php.net/manual/en/function.list.php) 不再按照相反顺序插入元素
-[list\(\)](http://php.net/manual/en/function.list.php)函数从此开始按照原数组中的顺序插入到函数参数制定的位置上，不再翻转数据。这点修改只会作用在[list\(\)](http://php.net/manual/en/function.list.php)函数参数一起用了数组的\[\]符号时。举例如下：
+[list\(\)](http://php.net/manual/en/function.list.php) 函数从此开始按照原数组中的顺序插入到函数参数制定的位置上，不再翻转数据。这点修改只会作用在 [list\(\)](http://php.net/manual/en/function.list.php) 函数参数一起用了数组的 `[]` 符号时。举例如下：
 ```PHP
 <?php
 list($a[], $a[], $a[]) = [1, 2, 3];
 var_dump($a);
 ?>
 ```
-上述例子在PHP5中的输出为：
+上述例子在 PHP5 中的输出为：
 ```PHP
 array(3) {
   [0]=>
@@ -43,7 +43,7 @@ array(3) {
   int(1)
 }
 ```
-而在PHP7中的输出为：
+而在 PHP7 中的输出为：
 ```php
 array(3) {
   [0]=>
@@ -54,7 +54,7 @@ array(3) {
   int(3)
 }
 ```
-在实际开发中，不建议使用依靠 [list\(\)](http://php.net/manual/en/function.list.php) 函数的参数来做排顺序这一操作，毕竟这样的hack用法在未来依然有可能被调整。
+在实际开发中，不建议使用依靠 [list\(\)](http://php.net/manual/en/function.list.php) 函数的参数来做排顺序这一操作，毕竟这样的 hack 用法在未来依然有可能被调整。
 
 ##### [list\(\)](http://php.net/manual/en/function.list.php) 函数参数不再允许为空
 [list\(\)](http://php.net/manual/en/function.list.php) 构造时不再允许参数为空的情况，下列情况将不再支持！
@@ -67,7 +67,7 @@ list($x, list(), $y) = $a;
 ```
 
 ##### [list\(\)](http://php.net/manual/en/function.list.php) 函数不再支持拆解字符串
-[list\(\)](http://php.net/manual/en/function.list.php) 不再允许拆解[字符串](http://php.net/manual/en/language.types.string.php)变量为字母，[str_split](http://php.net/manual/en/function.str-split.php)函数可以用于做此事。
+[list\(\)](http://php.net/manual/en/function.list.php) 不再允许拆解[字符串](http://php.net/manual/en/language.types.string.php)变量为字母，[str_split](http://php.net/manual/en/function.str-split.php) 函数可以用于做此事。
 
 #### 在数组中的元素通过引用方式创建时，数组顺序会被改变
 数组中的元素在通过引用方式创建时，其数组顺序会被自动的改变。例如：
@@ -79,7 +79,7 @@ $array["b"] = 1;
 var_dump($array);
 ?>
 ```
-PHP5中的输出：
+PHP5 中的输出：
 ```PHP
 array(2) {
   ["b"]=>
@@ -88,7 +88,7 @@ array(2) {
   &int(1)
 }
 ```
-PHP7中的输出
+PHP7 中的输出
 ```PHP
 array(2) {
   ["a"]=>
@@ -111,10 +111,10 @@ function f() {
 }
 ?>
 ```
-作为一个基本原则，这样的变量套变量的使用方式，在[global](http://php.net/manual/en/language.variables.scope.php#language.variables.scope.global)这种场景下不被提倡。
+作为一个基本原则，这样的变量套变量的使用方式，在 [global](http://php.net/manual/en/language.variables.scope.php#language.variables.scope.global) 这种场景下不被提倡。
 
 #### 函数参数中的括号不再影响(行为?)
-在PHP5中，参数若使被引用的并且使用括号，会没有报错发生。但在PHP7开始，这种场景都会印发一个报错。
+在 PHP5 中，参数若使被引用的并且使用括号，会没有报错发生。但在 PHP7 开始，这种场景都会引发一个报错。
 ```PHP
 <?php
 function getArray() {
@@ -140,7 +140,7 @@ Notice: Only variables should be passed by reference in /tmp/test.php on line 13
 关于 [foreach](http://php.net/manual/en/control-structures.foreach.php) 的修改比较少，主要是修改了数组遍历时的数组指针，以及修改了数组的迭代。
 
 #### [foreach](http://php.net/manual/en/control-structures.foreach.php) 遍历期间不再修改数组指针
-在PHP7之前，当数组通过[foreach](http://php.net/manual/en/control-structures.foreach.php)迭代时，数组指针会移动。现在开始，不再如此，见下面代码：
+在 PHP7 之前，当数组通过 [foreach](http://php.net/manual/en/control-structures.foreach.php) 迭代时，数组指针会移动。现在开始，不再如此，见下面代码：
 ```PHP
 <?php
 $array = [0, 1, 2];
@@ -149,13 +149,13 @@ foreach ($array as &$val) {
 }
 ?>
 ```
-PHP5中的输出
+PHP5 中的输出
 ```PHP
 int(1)
 int(2)
 bool(false)
 ```
-PHP7中的输出
+PHP7 中的输出
 ```PHP
 int(0)
 int(0)
@@ -163,10 +163,10 @@ int(0)
 ```
 
 #### [foreach](http://php.net/manual/en/control-structures.foreach.php) 通过值遍历时，操作的值为数组的副本
-当默认使用通过值遍历数组时，[foreach](http://php.net/manual/en/control-structures.foreach.php)实际操作的是数组的迭代副本，而非数组本身。这就意味着，[foreach](http://php.net/manual/en/control-structures.foreach.php)中的操作不会修改原数组的值。
+当默认使用通过值遍历数组时，[foreach](http://php.net/manual/en/control-structures.foreach.php) 实际操作的是数组的迭代副本，而非数组本身。这就意味着，[foreach](http://php.net/manual/en/control-structures.foreach.php) 中的操作不会修改原数组的值。
 
 #### [foreach](http://php.net/manual/en/control-structures.foreach.php) 通过引用遍历时，有更好的迭代特性
-当使用引用遍历数组时，现在[foreach](http://php.net/manual/en/control-structures.foreach.php)在迭代中更好的跟踪变化。例如，在迭代中添加一个迭代值到数组中，例如下面代码：
+当使用引用遍历数组时，现在 [foreach](http://php.net/manual/en/control-structures.foreach.php) 在迭代中更好的跟踪变化。例如，在迭代中添加一个迭代值到数组中，例如下面代码：
 ```PHP
 <?php
 $array = [0];
@@ -176,11 +176,11 @@ foreach ($array as &$val) {
 }
 ?>
 ```
-在PHP5的输出为：
+在PHP5 的输出为：
 ```PHP
 int(0)
 ```
-在PHP7的输出为：
+在PHP7 的输出为：
 ```PHP
 int(0)
 int(1)
@@ -191,7 +191,7 @@ int(1)
 
 ### [整型](http://php.net/manual/en/language.types.integer.php)处理上的调整
 #### 无效的八进制常量
-此前，八进制中包含无效数据会自动被截断（0128被当做为012）。现在，一个无效的八进制字面会造成分析错误。
+此前，八进制中包含无效数据会自动被截断（0128 被当做为 012）。现在，一个无效的八进制字面会造成分析错误。
 
 #### 负位置
 位移的负数将抛出一个 [ArithmeticError](http://php.net/manual/en/class.arithmeticerror.php)
@@ -200,11 +200,11 @@ int(1)
 var_dump(1 >> -1);
 ?>
 ```
-PHP5中的输出：
+PHP5 中的输出：
 ```PHP
 int(0)
 ```
-PHP7中的输出：
+PHP7 中的输出：
 ```PHP
 Fatal error: Uncaught ArithmeticError: Bit shift by negative number in /tmp/test.php:2
 Stack trace:
@@ -212,7 +212,7 @@ Stack trace:
   thrown in /tmp/test.php on line 2
 ```
 #### 超出范围的位移
-位移（任一方向）超出一个整数的位宽度会得到0。以前，这种转变的行为是依赖于运行环境的机器架构结构。
+位移（任一方向）超出一个整数的位宽度会得到 0。以前，这种转变的行为是依赖于运行环境的机器架构结构。
 
 ### [字符串](http://php.net/manual/en/language.types.string.php)处理上的调整
 #### 十六进制字符串不再被认为是数字
@@ -225,14 +225,14 @@ var_dump("0xe" + "0x1");
 var_dump(substr("foo", "0x1"));
 ?>
 ```
-在PHP5中得输出：
+在 PHP5 中的输出：
 ```PHP
 bool(true)
 bool(true)
 int(15)
 string(2) "oo"
 ```
-在PHP7中得输出：
+在 PHP7 中的输出：
 ```PHP
 bool(false)
 bool(false)
@@ -254,30 +254,30 @@ var_dump($int); // int(65535)
 ```
 
 #### \u{ 可能触发错误
-由于新的[Unicode转译语法](http://php.net/manual/en/migration70.new-features.php#migration70.new-features.unicode-codepoint-escape-syntax)，字符串中含有 **\\u{ ** 时会触发Fatal错误。为了避免这一报错，应该避免反斜杠开头。
+由于新的 [Unicode 转译语法](http://php.net/manual/en/migration70.new-features.php#migration70.new-features.unicode-codepoint-escape-syntax)，字符串中含有 **\\u{ ** 时会触发Fatal错误。为了避免这一报错，应该避免反斜杠开头。
 
 ### 被移除的函数
 #### [call_user_method\(\)](http://php.net/manual/en/function.call-user-method.php) 与 [call_user_method_array\(\)](http://php.net/manual/en/function.call-user-method-array.php)
-这些函数被在PHP4.1.0开始被标记为过时的，在PHP7开始被删除。建议使用 [call_user_func\(\)](http://php.net/manual/en/function.call-user-func.php) 和 [call_user_func_array\(\)](http://php.net/manual/en/function.call-user-func-array.php) 。你可以考虑下 [变量函数](http://php.net/manual/en/functions.variable-functions.php)或者参考其他函数。
+这些函数被在 PHP4.1.0 开始被标记为过时的，在 PHP7 开始被删除。建议使用 [call_user_func\(\)](http://php.net/manual/en/function.call-user-func.php) 和 [call_user_func_array\(\)](http://php.net/manual/en/function.call-user-func-array.php) 。你可以考虑下 [变量函数](http://php.net/manual/en/functions.variable-functions.php)或者参考其他函数。
 
 #### [mcrypt](http://php.net/manual/en/book.mcrypt.php) 相关
-mcrypt_generic_end\(\) 被删除，建议使用 mcrypt_generic_deinit\(\) 。
-此外，废弃的mcrypt_ecb\(\)，mcrypt_cbc\(\)，mcrypt_cfb\(\)和mcrypt_ofb\(\)功能，建议使用目前还支持的mcrypt_decrypt()与适当的MCRYPT_MODE_\*常量。
+`mcrypt_generic_end()` 被删除，建议使用 `mcrypt_generic_deinit()` 。
+此外，废弃的`mcrypt_ecb()`，`mcrypt_cbc()`，`mcrypt_cfb()` 和 `mcrypt_ofb()` 功能，建议使用目前还支持的 `mcrypt_decrypt()` 与适当的 `MCRYPT_MODE_*` 常量。
 
 #### [intl](http://php.net/manual/en/book.intl.php) 相关
-datefmt_set_timezone_id\(\)与IntlDateFormatter::setTimeZoneID\(\)被删除，建议使用datefmt_set_timezone\(\)与IntlDateFormatter::setTimeZone\(\)。
+`datefmt_set_timezone_id()` 与 `IntlDateFormatter::setTimeZoneID()` 被删除，建议使用 `datefmt_set_timezone()` 与 `IntlDateFormatter::setTimeZone()` 。
 
 #### [set_magic_quotes_runtime\(\)](http://php.net/manual/en/function.set-magic-quotes-runtime.php)
-set_magic_quotes_runtime\(\)与它的别名函数magic_quotes_runtime\(\)被删除。他们在PHP5.3.0中就被标记被过时的。
+`set_magic_quotes_runtime()` 与它的别名函数 `magic_quotes_runtime()` 被删除。他们在 PHP5.3.0 中就被标记被过时的。
 
 #### [set_socket_blocking\(\)](http://php.net/manual/en/function.set-socket-blocking.php)
-set_socket_blocking\(\)已被移除，建议使用stream_set_blocking\(\)。
+`set_socket_blocking()` 已被移除，建议使用 `stream_set_blocking()`。
 
 #### [dl\(\)](http://php.net/manual/en/function.dl.php) 在PHP-FPM中
-dl\(\)函数不能在PHP-FPM中使用了，它的功能做在了CLI、嵌入到SAPIs中了。
+`dl()` 函数不能在 PHP-FPM 中使用了，它的功能做在了 CLI、嵌入到 SAPIs 中了。
 
 #### [GD](http://php.net/manual/en/book.image.php) 类型的函数
-PostScript Type1字体的支持已经从GD扩展删除，涉及的函数有：
+PostScript Type1 字体的支持已经从 GD 扩展删除，涉及的函数有：
 * imagepsbbox()
 * imagepsencodefont()
 * imagepsextendfont()
@@ -285,7 +285,7 @@ PostScript Type1字体的支持已经从GD扩展删除，涉及的函数有：
 * imagepsloadfont()
 * imagepsslantfont()
 * imagepstext()
-建议使用TrueType字体和其相关的功能代替。
+建议使用 TrueType 字体和其相关的功能代替。
 
 ### 删除INI配置
 #### 删除的功能
@@ -294,28 +294,28 @@ PostScript Type1字体的支持已经从GD扩展删除，涉及的函数有：
 * [asp_tags](http://php.net/manual/en/ini.core.php#ini.asp-tags)
 
 #### xsl.security_prefs
-xsl.security_prefs指令已被删除。相反，该[xsltprocessor::setsecurityprefs\(\)](http://php.net/manual/en/xsltprocessor.setsecurityprefs.php)方法用于控制在每个处理器上的安全选项。
+xsl.security_prefs 指令已被删除。相反，该 [xsltprocessor::setsecurityprefs\(\)](http://php.net/manual/en/xsltprocessor.setsecurityprefs.php) 方法用于控制在每个处理器上的安全选项。
 
 ### 其他不向后兼容的变更
 #### [New](http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.new) 对象不能被引用分配
-[New](http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.new)语句的结果不再能通过引用赋值给一个变量，如下代码：
+[New](http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.new) 语句的结果不再能通过引用赋值给一个变量，如下代码：
 ```PHP
 <?php
 class C {}
 $c =& new C;
 ?>
 ```
-PHP5中的输出：
+PHP5 中的输出：
 ```PHP
 Deprecated: Assigning the return value of new by reference is deprecated in /tmp/test.php on line 3
 ```
-PHP7中的输出：
+PHP7 中的输出：
 ```PHP
 Parse error: syntax error, unexpected 'new' (T_NEW) in /tmp/test.php on line 3
 ```
 
 #### 无效的类、接口和特性的名字
-下面的名称不能被用来类、接口、特性的名称：
+下面的名称不能被用来作为类、接口、特性的名称：
 * bool
 * int
 * float
@@ -323,18 +323,19 @@ Parse error: syntax error, unexpected 'new' (T_NEW) in /tmp/test.php on line 3
 * NULL
 * TRUE
 * FALSE
-此外，不推荐下列名称，他们已被标记过时
+
+此外，不推荐下列名称，它们已被标记过时
 * resource
 * object
 * mixed
 * numeric
 
-#### ASP语法标记、Script PHP语法标记被移除
-使用ASP脚本标签，或者Script的PHP代码，已被删除。受影响的标签是：
+#### ASP 语法标记、Script PHP 语法标记被移除
+使用 ASP 脚本标签，或者 Script 的 PHP 代码，已被删除。受影响的标签是：
 ![image](https://cloud.githubusercontent.com/assets/1308846/9438212/bdeec078-4a8e-11e5-91b5-5e6b92e4019d.png)
 
 #### 禁止调用不确定的情况
-[之前PHP5.6的过时说明中](http://php.net/manual/en/migration56.deprecated.php#migration56.deprecated.incompatible-context)，静态调用一个非静态方法，会在静态调用中被提示未定义 $this ，并会报错。
+[之前 PHP5.6 的过时说明中](http://php.net/manual/en/migration56.deprecated.php#migration56.deprecated.incompatible-context)，静态调用一个非静态方法，会在静态调用中被提示未定义 $this ，并会报错。
 ```PHP
 <?php
 class A {
@@ -349,13 +350,13 @@ class B {
 (new B)->callNonStaticMethodOfA();
 ?>
 ```
-在PHP5中会输出：
+在 PHP5 中会输出：
 ```PHP
 Deprecated: Non-static method A::test() should not be called statically, assuming $this from incompatible context in /tmp/test.php on line 8
 object(B)#1 (0) {
 }
 ```
-在PHP7中会输出：
+在 PHP7 中会输出：
 ```PHP
 Deprecated: Non-static method A::test() should not be called statically in /tmp/test.php on line 8
 
@@ -363,7 +364,7 @@ Notice: Undefined variable: this in /tmp/test.php on line 3
 NULL
 ```
 #### [yield]() 现在开始作为(右)关联运算符
-yield 不再需要括号，可以作为一个（右）关联运算符，优先于 **print** 与 ** => **，这将产生下列行为：
+yield 不再需要括号，可以作为一个（右）关联运算符，优先于 **print** 与 ` => `，这将产生下列行为：
 
 ```PHP
 <?php
@@ -393,10 +394,10 @@ function foo($a, $b, $unused, $unused) {
 ```
 
 #### [$HTTP_RAW_POST_DATA](http://php.net/manual/en/reserved.variables.httprawpostdata.php) 被移除
-$HTTP_RAW_POST_DATA 不再被支持。 可以使用 php://input 流数据来代替实现。
+`$HTTP_RAW_POST_DATA` 不再被支持。 可以使用 php://input 流数据来代替实现。
 
 #### \# 注释已被移除
-INI文件中以\#符号作为注释的内容已被移除，**;**符号将代替**\#**，这个改变同样适用于PHP.ini文件，以及parse_ini_file()和parse_ini_string()处理文件期间。
+INI 文件中以 \# 符号作为注释的内容已被移除，**;** 符号将代替 **\#**，这个改变同样适用于PHP.ini文件，以及 `parse_ini_file()` 和 `parse_ini_string()` 处理文件期间。
 
 ## 用户贡献说明
 暂无

--- a/Backward-incompatible-changes.md
+++ b/Backward-incompatible-changes.md
@@ -261,7 +261,7 @@ var_dump($int); // int(65535)
 这些函数被在 PHP4.1.0 开始被标记为过时的，在 PHP7 开始被删除。建议使用 [call_user_func\(\)](http://php.net/manual/en/function.call-user-func.php) 和 [call_user_func_array\(\)](http://php.net/manual/en/function.call-user-func-array.php) 。你可以考虑下[变量函数](http://php.net/manual/en/functions.variable-functions.php)或者参考其他函数。
 
 #### [mcrypt](http://php.net/manual/en/book.mcrypt.php) 相关
-[mcrypt_generic_end\(\)(http://php.net/manual/en/function.mcrypt-generic-end.php) 被删除，建议使用 [mcrypt_generic_deinit\(\)](http://php.net/manual/en/function.mcrypt-generic-deinit.php) 。
+[mcrypt_generic_end\(\)](http://php.net/manual/en/function.mcrypt-generic-end.php) 被删除，建议使用 [mcrypt_generic_deinit\(\)](http://php.net/manual/en/function.mcrypt-generic-deinit.php) 。
 此外，废弃的[mcrypt_ecb\(\)](http://php.net/manual/en/function.mcrypt-ecb.php)，[mcrypt_cbc\(\)](http://php.net/manual/en/function.mcrypt-cbc.php)，[mcrypt_cfb\(\)](http://php.net/manual/en/function.mcrypt-cfb.php) 和 [mcrypt_ofb\(\)](http://php.net/manual/en/function.mcrypt-ofb.php) 功能，建议使用目前还支持的 [mcrypt_decrypt\(\)](http://php.net/manual/en/function.mcrypt-decrypt.php) 与适当的 MCRYPT_MODE_* 常量。
 
 #### [intl](http://php.net/manual/en/book.intl.php) 相关

--- a/Backward-incompatible-changes.md
+++ b/Backward-incompatible-changes.md
@@ -2,13 +2,13 @@
 ## 向后兼容说明
 ### 错误和异常处理的变更
 许多可以被修正的 Fatal 错误，在 PHP7 中将以 Exceptions 异常的形式抛出。这些 Error Exceptions 继承于 [Error](http://php.net/manual/en/class.error.php) 类。而 [Error](http://php.net/manual/en/class.error.php) 类则实现了异常基类 [Throwable](http://php.net/manual/en/class.throwable.php) 接口。 <br>
-PHP7中详细的Error信息可以参考\[ [PHP7错误](http://php.net/manual/en/language.errors.php7.php) \]。本文中仅仅介绍和向后兼容有关的信息如下。
+PHP7 中详细的 Error 信息可以参考 [PHP7 错误](http://php.net/manual/en/language.errors.php7.php) 。本文中仅仅介绍和向后兼容有关的信息如下。
 
 #### 类构造函数在失败时抛出异常
 之前，类构造函数在失败时总是返回NULL或者返回一个不可用的 Object，但从 PHP7 开始，在构造函数初始化失败时会抛出[异常](http://php.net/manual/en/class.exception.php)。
 
 #### 解析错误时会抛出 [解析异常](http://php.net/manual/en/class.parseerror.php)
-现在，解析[eval\(\)]错误会抛出一个 [解析异常](http://php.net/manual/en/class.parseerror.php) 对象。其可以通过 [catch](http://php.net/manual/en/language.exceptions.php#language.exceptions.catch) 捕捉，并做相应处理。
+现在，解析 [eval\(\)](http://php.net/manual/en/function.eval.php) 错误会抛出一个 [解析异常](http://php.net/manual/en/class.parseerror.php) 对象。其可以通过 [catch](http://php.net/manual/en/language.exceptions.php#language.exceptions.catch) 捕捉，并做相应处理。
 
 #### E_STRICT 等级的报错被重新分配
 所有**E_STRICT**级别的报错已重新分配到其他报错等级中。**E_STRICT** 常量依然保留，所以当你设置报错等级为 **error_reporting\(E_ALL|E_STRICT\)** 时，不会引起报错。<br>
@@ -19,9 +19,9 @@ PHP7中详细的Error信息可以参考\[ [PHP7错误](http://php.net/manual/en/
 由于 PHP7 采用抽象的语法树解析代码文件，并且过去的 PHP 版本无法满足该特性，这一变化将引起一些一致性问题。本节详细介绍这块的情况。
 
 #### 对于间接变量、属性、方法的变动
-间接的使用变量、属性、方法，将严格按照从左到右的顺序执行，而不会因形式问题导致歧义。下表将表明的这一改变引起的差异。
+间接的使用变量、属性、方法，将严格按照从左到右的顺序执行，而不会因形式问题导致歧义。下表将表明这一改变引起的差异。
 ![image](https://cloud.githubusercontent.com/assets/1308846/9435404/1bf947a2-4a7a-11e5-97bb-96677cc560fb.png)
-以上使用老得从右到左的方式的代码，将被重写。通过花括号来明确顺序（见上图中间列），使代码向前兼容PHP7.x，并向后兼容PHP5.x。
+以上使用老的从右到左的方式的代码，将被重写。通过花括号来明确顺序（见上图中间列），使代码向前兼容 PHP7.x，并向后兼容 PHP5.x。
 
 #### 对于 [list\(\)](http://php.net/manual/en/function.list.php) 函数处理上的修改
 ##### [list\(\)](http://php.net/manual/en/function.list.php) 不再按照相反顺序插入元素
@@ -99,7 +99,7 @@ array(2) {
 ```
 
 #### [global](http://php.net/manual/en/language.variables.scope.php#language.variables.scope.global) 仅支持简单的变量
-[可变变量](http://php.net/manual/en/language.variables.variable.php)将不能再使用[global](http://php.net/manual/en/language.variables.scope.php#language.variables.scope.global)标记。如果真的需要，可以用花括号来间隔开写，例如下面代码：
+[可变变量](http://php.net/manual/en/language.variables.variable.php)将不能再使用 [global](http://php.net/manual/en/language.variables.scope.php#language.variables.scope.global) 标记。如果真的需要，可以用花括号来间隔开写，例如下面代码：
 ```PHP
 <?php
 function f() {
@@ -114,7 +114,7 @@ function f() {
 作为一个基本原则，这样的变量套变量的使用方式，在 [global](http://php.net/manual/en/language.variables.scope.php#language.variables.scope.global) 这种场景下不被提倡。
 
 #### 函数参数中的括号不再影响(行为?)
-在 PHP5 中，参数若使被引用的并且使用括号，会没有报错发生。但在 PHP7 开始，这种场景都会引发一个报错。
+在 PHP5 中，函数引用参数如果匹配括号操作，不会触发严格标准警告。但从 PHP7 开始，这种场景都会引发一个警告信息。
 ```PHP
 <?php
 function getArray() {
@@ -166,7 +166,7 @@ int(0)
 当默认使用通过值遍历数组时，[foreach](http://php.net/manual/en/control-structures.foreach.php) 实际操作的是数组的迭代副本，而非数组本身。这就意味着，[foreach](http://php.net/manual/en/control-structures.foreach.php) 中的操作不会修改原数组的值。
 
 #### [foreach](http://php.net/manual/en/control-structures.foreach.php) 通过引用遍历时，有更好的迭代特性
-当使用引用遍历数组时，现在 [foreach](http://php.net/manual/en/control-structures.foreach.php) 在迭代中更好的跟踪变化。例如，在迭代中添加一个迭代值到数组中，例如下面代码：
+当使用引用遍历数组时，现在 [foreach](http://php.net/manual/en/control-structures.foreach.php) 在迭代中能更好的跟踪变化。例如，在迭代中添加一个迭代值到数组中，例如下面代码：
 ```PHP
 <?php
 $array = [0];
@@ -258,23 +258,23 @@ var_dump($int); // int(65535)
 
 ### 被移除的函数
 #### [call_user_method\(\)](http://php.net/manual/en/function.call-user-method.php) 与 [call_user_method_array\(\)](http://php.net/manual/en/function.call-user-method-array.php)
-这些函数被在 PHP4.1.0 开始被标记为过时的，在 PHP7 开始被删除。建议使用 [call_user_func\(\)](http://php.net/manual/en/function.call-user-func.php) 和 [call_user_func_array\(\)](http://php.net/manual/en/function.call-user-func-array.php) 。你可以考虑下 [变量函数](http://php.net/manual/en/functions.variable-functions.php)或者参考其他函数。
+这些函数被在 PHP4.1.0 开始被标记为过时的，在 PHP7 开始被删除。建议使用 [call_user_func\(\)](http://php.net/manual/en/function.call-user-func.php) 和 [call_user_func_array\(\)](http://php.net/manual/en/function.call-user-func-array.php) 。你可以考虑下[变量函数](http://php.net/manual/en/functions.variable-functions.php)或者参考其他函数。
 
 #### [mcrypt](http://php.net/manual/en/book.mcrypt.php) 相关
-`mcrypt_generic_end()` 被删除，建议使用 `mcrypt_generic_deinit()` 。
-此外，废弃的`mcrypt_ecb()`，`mcrypt_cbc()`，`mcrypt_cfb()` 和 `mcrypt_ofb()` 功能，建议使用目前还支持的 `mcrypt_decrypt()` 与适当的 `MCRYPT_MODE_*` 常量。
+[mcrypt_generic_end\(\)(http://php.net/manual/en/function.mcrypt-generic-end.php) 被删除，建议使用 [mcrypt_generic_deinit\(\)](http://php.net/manual/en/function.mcrypt-generic-deinit.php) 。
+此外，废弃的[mcrypt_ecb\(\)](http://php.net/manual/en/function.mcrypt-ecb.php)，[mcrypt_cbc\(\)](http://php.net/manual/en/function.mcrypt-cbc.php)，[mcrypt_cfb\(\)](http://php.net/manual/en/function.mcrypt-cfb.php) 和 [mcrypt_ofb\(\)](http://php.net/manual/en/function.mcrypt-ofb.php) 功能，建议使用目前还支持的 [mcrypt_decrypt\(\)](http://php.net/manual/en/function.mcrypt-decrypt.php) 与适当的 MCRYPT_MODE_* 常量。
 
 #### [intl](http://php.net/manual/en/book.intl.php) 相关
-`datefmt_set_timezone_id()` 与 `IntlDateFormatter::setTimeZoneID()` 被删除，建议使用 `datefmt_set_timezone()` 与 `IntlDateFormatter::setTimeZone()` 。
+[datefmt_set_timezone_id\(\)](http://php.net/manual/en/intldateformatter.settimezoneid.php) 与 [IntlDateFormatter::setTimeZoneID\(\)](http://php.net/manual/en/intldateformatter.settimezoneid.php) 被删除，建议使用 [datefmt_set_timezone\(\)](http://php.net/manual/en/intldateformatter.settimezone.php) 与 [IntlDateFormatter::setTimeZone\(\)](http://php.net/manual/en/intldateformatter.settimezone.php) 。
 
 #### [set_magic_quotes_runtime\(\)](http://php.net/manual/en/function.set-magic-quotes-runtime.php)
-`set_magic_quotes_runtime()` 与它的别名函数 `magic_quotes_runtime()` 被删除。他们在 PHP5.3.0 中就被标记被过时的。
+[set_magic_quotes_runtime\(\)](http://php.net/manual/en/function.set-magic-quotes-runtime.php) 与它的别名函数 [magic_quotes_runtime\(\)](http://php.net/manual/en/function.magic-quotes-runtime.php) 被删除。他们在 PHP5.3.0 中就被标记被过时的。
 
 #### [set_socket_blocking\(\)](http://php.net/manual/en/function.set-socket-blocking.php)
-`set_socket_blocking()` 已被移除，建议使用 `stream_set_blocking()`。
+[set_socket_blocking\(\)](http://php.net/manual/en/function.set-socket-blocking.php) 已被移除，建议使用 [stream_set_blocking\(\)](http://php.net/manual/en/function.stream-set-blocking.php)。
 
 #### [dl\(\)](http://php.net/manual/en/function.dl.php) 在PHP-FPM中
-`dl()` 函数不能在 PHP-FPM 中使用了，它的功能做在了 CLI、嵌入到 SAPIs 中了。
+[dl\(\)](http://php.net/manual/en/function.dl.php) 函数不能在 PHP-FPM 中使用了，它的功能做在了 CLI、嵌入到 SAPIs 中了。
 
 #### [GD](http://php.net/manual/en/book.image.php) 类型的函数
 PostScript Type1 字体的支持已经从 GD 扩展删除，涉及的函数有：
@@ -324,7 +324,7 @@ Parse error: syntax error, unexpected 'new' (T_NEW) in /tmp/test.php on line 3
 * TRUE
 * FALSE
 
-此外，不推荐下列名称，它们已被标记过时
+此外，不推荐下列名称，它们已被标记为过时
 * resource
 * object
 * mixed
@@ -363,8 +363,8 @@ Deprecated: Non-static method A::test() should not be called statically in /tmp/
 Notice: Undefined variable: this in /tmp/test.php on line 3
 NULL
 ```
-#### [yield]() 现在开始作为(右)关联运算符
-yield 不再需要括号，可以作为一个（右）关联运算符，优先于 **print** 与 ` => `，这将产生下列行为：
+#### [yield](http://php.net/manual/en/language.generators.syntax.php#control-structures.yield) 现在开始作为(右)关联运算符
+[yield](http://php.net/manual/en/language.generators.syntax.php#control-structures.yield) 不再需要括号，可以作为一个（右）关联运算符，优先于 `print` 与 ` => `，这将产生下列行为：
 
 ```PHP
 <?php
@@ -397,7 +397,7 @@ function foo($a, $b, $unused, $unused) {
 `$HTTP_RAW_POST_DATA` 不再被支持。 可以使用 php://input 流数据来代替实现。
 
 #### \# 注释已被移除
-INI 文件中以 \# 符号作为注释的内容已被移除，**;** 符号将代替 **\#**，这个改变同样适用于PHP.ini文件，以及 `parse_ini_file()` 和 `parse_ini_string()` 处理文件期间。
+INI 文件中以 \# 符号作为注释的内容已被移除，**;** 符号将代替 **\#**，这个改变同样适用于 `PHP.ini` 文件，以及 [parse_ini_file\(\)](http://php.net/manual/en/function.parse-ini-file.php) 和 [parse_ini_string\(\)](http://php.net/manual/en/function.parse-ini-string.php) 处理文件期间。
 
 ## 用户贡献说明
 暂无

--- a/Changed-functions.md
+++ b/Changed-functions.md
@@ -5,8 +5,8 @@
 * [dirname()](http://php.net/manual/en/function.dirname.php) 现有第二个参数(depth)可选，基于当前目录获取目录名称深度。
 * [getrusage()](http://php.net/manual/en/function.getrusage.php) 不再支持windows系统
 * [mktime()](http://php.net/manual/en/function.mktime.php) 及 [gmmktime()](http://php.net/manual/en/function.gmmktime.php) 不再接受 is_dst 参数。
-* [preg_replace()](http://php.net/manual/en/function.preg-replace.php) 不再支持 \e (PREG_REPLACE_EVAL). 以 preg_replace_callback() 作为替代。
-* [setlocale()](http://php.net/manual/en/function.setlocale.php) 第一个参数不再接受字符串。必须用LC_*系列常亮代替。
+* [preg_replace()](http://php.net/manual/en/function.preg-replace.php) 不再支持` \e (PREG_REPLACE_EVAL)`. 以 `preg_replace_callback()` 作为替代。
+* [setlocale()](http://php.net/manual/en/function.setlocale.php) 第一个参数不再接受字符串。必须用 `LC_*` 系列常亮代替。
 * exec()、system()、passthru() 函数现在具备空字节保护。
 
 ## 用户贡献记录

--- a/Deprecated.md
+++ b/Deprecated.md
@@ -1,7 +1,7 @@
 # PHP 5.6.x 版本迁移至 PHP 7.0.x 版本
-## 7.0.x版本开始停用的特性
-### PHP4风格的构造函数
-在PHP4中类中的函数可以与类名同名，这一特性在PHP7中被废弃，同时会发出一个 E_DEPRECATED 错误。当方法名与类名相同，且类不在命名空间中，同时PHP5的构造函数（__construct）不存在时，会产生一个E_DEPRECATED错误。
+## 7.0.x 版本开始停用的特性
+### PHP4 风格的构造函数
+在 PHP4 中类中的函数可以与类名同名，这一特性在 PHP7 中被废弃，同时会发出一个 E_DEPRECATED 错误。当方法名与类名相同，且类不在命名空间中，同时PHP5的构造函数（__construct）不存在时，会产生一个 E_DEPRECATED 错误。
 ```PHP
 <?php
 class foo {
@@ -17,7 +17,7 @@ Deprecated: Methods with the same name as their class will not be constructors i
 ```
 
 ### password_hash() 随机因子选项
-函数原salt量不再需要由开发者提供了。函数内部默认带有salt能力，无需开发者提供salt值。
+函数原 salt 量不再需要由开发者提供了。函数内部默认带有 salt 能力，无需开发者提供 salt 值。
 
 ## 用户贡献记录
 暂无

--- a/New-features.md
+++ b/New-features.md
@@ -1,7 +1,7 @@
-# PHP5.6.x版本迁移至7.0.x版本
+# PHP5.6.x 版本迁移至 7.0.x 版本
 ## 新的特性
 ### 标量类型声明
-标量类型声明有两种模式：强制（默认）模式、严格模式。下列参数类型可以使用（无论用强制模式还是严格模式）：字符串（string）、整形（int）、浮点数（float）和布尔型（bool）。其他类型在PHP5中有支持：类名、接口、数组和可被调用的。
+标量类型声明有两种模式：强制（默认）模式、严格模式。下列参数类型可以使用（无论用强制模式还是严格模式）：字符串（string）、整形（int）、浮点数（float）和布尔型（bool）。其他类型在 PHP5 中有支持：类名、接口、数组和可被调用的。
 ```PHP
 <?php
 // Coercive mode
@@ -16,11 +16,11 @@ var_dump(sumOfInts(2, '3', 4.1));
 ```PHP
 int(9)
 ```
-当开启严格模式后，一个 [declare](http://php.net/manual/en/control-structures.declare.php) 声明必须置于PHP脚本文件开头，这意味着严格声明标量是基于文件可配的。这个指令不仅影响参数的类型声明，也影响到函数的返回值声明（详见下面的返回值声明）。<br>
+当开启严格模式后，一个 [declare](http://php.net/manual/en/control-structures.declare.php) 声明必须置于 PHP 脚本文件开头，这意味着严格声明标量是基于文件可配的。这个指令不仅影响参数的类型声明，也影响到函数的返回值声明（详见下面的返回值声明）。<br>
 详细的标量类型声明的文档与示例，可以查看[类型声明](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration)页面。
 
 ### 返回类型声明
-PHP7新增了返回类型声明，类似于参数类型声明，返回类型声明提前声明了函数返回值的类型。可用的声明类型与参数声明中可用的类型相同。
+PHP7 新增了返回类型声明，类似于参数类型声明，返回类型声明提前声明了函数返回值的类型。可用的声明类型与参数声明中可用的类型相同。
 ```PHP
 <?php
 
@@ -45,7 +45,7 @@ Array
 详细的返回值声明相关的文档和示例代码可以查阅[返回值声明](http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration)文档。
 
 ### NULL合并算子（操作符“??”）
-空合并算子的操作符为??，已经作为一种语法糖用于日常需求中用于三元表达式，它与isset()同时发生。如果变量存在且不为空，它就会返回对应的值，相反，它返回它的第二个操作数。
+空合并算子的操作符为 `??` ，已经作为一种语法糖用于日常需求中用于三元表达式，它与isset()同时发生。如果变量存在且不为空，它就会返回对应的值，相反，它返回它的第二个操作数。
 ```PHP
 <?php
 // Fetches the value of $_GET['user'] and returns 'nobody'
@@ -61,7 +61,7 @@ $username = $_GET['user'] ?? $_POST['user'] ?? 'nobody';
 ?>
 ```
 ### 太空船操作符（组合比较符，[RFC](https://wiki.php.net/rfc/combined-comparison-operator)）
-太空船操作符用于比较两个表达式。它返回一个大于0、等于0、小于0的数，用于表示$a与$b之间的关系。比较的原则是沿用PHP的[常规比较规则](http://php.net/manual/en/types.comparisons.php)进行的。
+太空船操作符用于比较两个表达式。它返回一个大于 0、等于 0、小于 0 的数，用于表示 $a 与 $b 之间的关系。比较的原则是沿用 PHP 的[常规比较规则](http://php.net/manual/en/types.comparisons.php)进行的。
 ```PHP
 <?php
 // Integers
@@ -80,8 +80,8 @@ echo "a" <=> "b"; // -1
 echo "b" <=> "a"; // 1
 ?>
 ```
-### 通过define()定义常量数组
-Array类型的常量可以通过define()来定义。在PHP5.6中仅能通过const定义。
+### 通过 define() 定义常量数组
+Array 类型的常量可以通过 define() 来定义。在 PHP5.6 中仅能通过 const 定义。
 ```PHP
 <?php
 define('ANIMALS', [
@@ -95,7 +95,7 @@ echo ANIMALS[1]; // outputs "cat"
 ```
 
 ### 匿名类
-可以通过new关键字初始化一个匿名类。匿名类使用场景与完整的类场景相同。
+可以通过 new 关键字初始化一个匿名类。匿名类使用场景与完整的类场景相同。
 ```PHP
 <?php
 interface Logger {
@@ -131,8 +131,8 @@ object(class@anonymous)#2 (0) {
 ```
 详细文档可以参考[匿名类文档](http://php.net/manual/en/language.oop5.anonymous.php)
 
-### Unicode codepoint转译语法
-通过十六进制内容与双引号组成的字符串生成Unicode codepoint，可以接受任何有效的codepoint，并且开头的0是可以省略的。
+### Unicode codepoint 转译语法
+通过十六进制内容与双引号组成的字符串生成 Unicode codepoint，可以接受任何有效的 codepoint，并且开头的 0 是可以省略的。
 ```PHP
 echo "\u{aa}";
 echo "\u{0000aa}";
@@ -144,7 +144,7 @@ echo "\u{9999}";
 ```
 
 ### [Closure::call()](http://php.net/manual/en/closure.call.php)
-闭包[Closure::call()](http://php.net/manual/en/closure.call.php)有着更好的性能，简短干练的暂时绑定一个方法到对象上闭包并调用它。
+闭包 [Closure::call()](http://php.net/manual/en/closure.call.php) 有着更好的性能，简短干练的暂时绑定一个方法到对象上闭包并调用它。
 ```PHP
 <?php
 class A {private $x = 1;}
@@ -180,7 +180,7 @@ $data = unserialize($foo, ["allowed_classes" => true]);
 ```
 
 ### [IntlChar](http://php.net/manual/en/class.intlchar.php)
-新增加的IntlChar类意在于暴露出更多的ICU功能。类自身定义了许多静态方法用于操作unicode字符。
+新增加的 IntlChar 类意在于暴露出更多的 ICU 功能。类自身定义了许多静态方法用于操作 unicode 字符。
 ```PHP
 <?php
 
@@ -197,8 +197,8 @@ bool(true)
 若要使用此类，请先安装Intl扩展。
 
 ### 预期 （增强的断言）
-预期（增强的断言）是向后兼用以增强assert()方法。在代码中启用断言为零成本，并且提供抛出特定异常的能力。<br>
-在使用老版本API时，如果第一个参数是一个字符串,那么它将被解析。第二个参数可以是一个简单的字符串(导致AssertionError被触发)，或一个包含一个错误消息的自定义异常对象。
+预期（增强的断言）是向后兼用以增强 assert() 方法。在代码中启用断言为零成本，并且提供抛出特定异常的能力。<br>
+在使用老版本 API 时，如果第一个参数是一个字符串,那么它将被解析。第二个参数可以是一个简单的字符串(导致 AssertionError 被触发)，或一个包含一个错误消息的自定义异常对象。
 ```PHP
 <?php
 
@@ -212,17 +212,19 @@ assert(false, new CustomError('Some error message'));
 ```PHP
 Fatal error: Uncaught CustomError: Some error message
 ```
-这个特性会带来两个PHP。ini设置(以及它们的默认值):
+这个特性会带来两个 PHP.ini 设置(以及它们的默认值):
 * zend.assertions = 1
 * assert.exception = 0
-zend.assertions有三种值：
+
+zend.assertions 有三种值：
 * 1 = 生成并且执行代码（开发模式）
 * 0 = 执行代码并且在运行期间跳来跳去
 * -1 = 不生成任何代码 (0开销, 生产模式)
+
 assert.exception意味着断言失败时抛出异常。默认关闭保持兼容旧的assert()函数。
 
-### 使用use集体声明
-在PHP7之前需要声明一大堆命名空间，但是现在可以通过use的新特性，批量声明。
+### 使用 use 集体声明
+在 PHP7 之前需要声明一大堆命名空间，但是现在可以通过 use 的新特性，批量声明。
 ```PHP
 <?php
 
@@ -308,8 +310,8 @@ echo $gen->getReturn();
 4
 ```
 
-### 通过intdiv()做整除
-intdiv()函数来处理整除，并返回一个整数。
+### 通过 intdiv() 做整除
+intdiv() 函数来处理整除，并返回一个整数。
 ```PHP
 <?php
 
@@ -321,17 +323,17 @@ int(3)
 ```
 
 ### session_start() 选项
-该特性给session_start()函数提供一些设置能力，当然这些设置可以在PHP.ini中设置。
+该特性给 session_start() 函数提供一些设置能力，当然这些设置可以在PHP.ini中设置。
 ```PHP
 <?php
 
 session_start(['cache_limiter' => 'private']); // sets the session.cache_limiter option to private
 ```
-这个特性还引入了一个新的php.ini设置(session.lazy_write)，默认情况下为true，表示改变会话数据只是重写。
+这个特性还引入了一个新的 php.ini 设置( session.lazy_write )，默认情况下为 true，表示改变会话数据只是重写。
 
 ### preg_replace_callback_array() 函数
-这个新功能，当你使用preg_replace_callback()函数时代码更清晰可读。在PHP7之前，每个正则表达式都需要回调（ preg_replace_callback() 函数的第二个参数 ）中来实现功能，这会使流程混乱不可控。<br>
-现在，回调可以通过与正则表达式绑定着写，只需将正则表达式作为key，回调函数作为value。
+这个新功能，当你使用 preg_replace_callback() 函数时代码更清晰可读。在PHP7之前，每个正则表达式都需要回调（ preg_replace_callback() 函数的第二个参数 ）中来实现功能，这会使流程混乱不可控。<br>
+现在，回调可以通过与正则表达式绑定着写，只需将正则表达式作为 key，回调函数作为 value。
 ```PHP
 <?php
 
@@ -390,14 +392,14 @@ preg_replace_callback_array(
 ```
 
 ### [CSPRNG](http://php.net/manual/en/book.csprng.php) 系列函数
-该特性涵盖两个函数，用于生成安全的整形与字符串，主要用于密码场景。它提供了简单的API和平台无关性。
+该特性涵盖两个函数，用于生成安全的整形与字符串，主要用于密码场景。它提供了简单的 API 和平台无关性。
 ```PHP
 string random_bytes(int length);
 int random_int(int min, int max);
 ```
-两个函数在没有足够的随机性时会报E_WARNING错误并且返回false。
+两个函数在没有足够的随机性时会报 E_WARNING 错误并且返回 false。
 
-### list()可以打开对象实现[ArrayAccess](http://php.net/manual/en/class.arrayaccess.php)
+### list() 可以打开对象实现 [ArrayAccess](http://php.net/manual/en/class.arrayaccess.php)
 
 ## 用户贡献记录
 暂无

--- a/New-features.md
+++ b/New-features.md
@@ -45,7 +45,7 @@ Array
 详细的返回值声明相关的文档和示例代码可以查阅[返回值声明](http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration)文档。
 
 ### NULL合并算子（操作符“??”）
-空合并算子的操作符为 `??` ，已经作为一种语法糖用于日常需求中用于三元表达式，它与isset()同时发生。如果变量存在且不为空，它就会返回对应的值，相反，它返回它的第二个操作数。
+空合并算子的操作符为 `??` ，已经作为一种语法糖用于日常需求中用于三元表达式，它与 isset() 同时发生。如果变量存在且不为空，它就会返回对应的值，相反，它返回它的第二个操作数。
 ```PHP
 <?php
 // Fetches the value of $_GET['user'] and returns 'nobody'
@@ -221,7 +221,7 @@ zend.assertions 有三种值：
 * 0 = 执行代码并且在运行期间跳来跳去
 * -1 = 不生成任何代码 (0开销, 生产模式)
 
-assert.exception意味着断言失败时抛出异常。默认关闭保持兼容旧的assert()函数。
+assert.exception 意味着断言失败时抛出异常。默认关闭保持兼容旧的 assert() 函数。
 
 ### 使用 use 集体声明
 在 PHP7 之前需要声明一大堆命名空间，但是现在可以通过 use 的新特性，批量声明。
@@ -323,7 +323,7 @@ int(3)
 ```
 
 ### session_start() 选项
-该特性给 session_start() 函数提供一些设置能力，当然这些设置可以在PHP.ini中设置。
+该特性给 session_start() 函数提供一些设置能力，当然这些设置可以在 PHP.ini 中设置。
 ```PHP
 <?php
 

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@
 * [新的函数](http://php.net/manual/en/migration70.new-functions.php)
 * [新的类与接口](http://php.net/manual/en/migration70.classes.php)
 * [新的全局常量](http://php.net/manual/en/migration70.constants.php)
-* [被移除的扩展与SAPIs](http://php.net/manual/en/migration70.removed-exts-sapis.php)
+* [被移除的扩展与 SAPIs](http://php.net/manual/en/migration70.removed-exts-sapis.php)
 * [其他修改](http://php.net/manual/en/migration70.other-changes.php)
 
 ## PHP7 依然处于开发中
 ```PHP
 [警告] 
     PHP7 目前仍处于开发中并且短时间内还不能完成，本文中的一些新
-    特性、修改还需等7.0版本正式发布后才能敲定（还有可能修改）。
-    请你在将PHP7部署到线上生成环境之前再来确认下最新的变更是否
+    特性、修改还需等 7.0 版本正式发布后才能敲定（还有可能修改）。
+    请你在将 PHP7 部署到线上生成环境之前再来确认下最新的变更是否
     对你的业务有影响。
 ```
 PHP7 是一个全新的大版本，我们在努力让大家做到无缝的升级。这次版本变更专注在移除旧特性以保证语言的一致性。<br>
 这里有一些已经被确定的[不兼容](./Backward-incompatible-changes.md)和[新特性](./New-features.md)，请大家切换生产环境的PHP版本到PHP7之前，这些环节需要特别关注测试。<br>
-这里提供一些其他PHP版本的升级指南：[5.0.x](http://php.net/manual/en/migration5.php), [5.1.x](http://php.net/manual/en/migration51.php), [5.2.x](http://php.net/manual/en/migration52.php), [5.3.x](http://php.net/manual/en/migration53.php), [5.4.x](http://php.net/manual/en/migration54.php), [5.5.x](http://php.net/manual/en/migration55.php), 和 [5.6.x](http://php.net/manual/en/migration56.php)
+这里提供一些其他PHP版本的升级指南：[5.0.x](http://php.net/manual/en/migration5.php)、 [5.1.x](http://php.net/manual/en/migration51.php)、 [5.2.x](http://php.net/manual/en/migration52.php)、 [5.3.x](http://php.net/manual/en/migration53.php)、 [5.4.x](http://php.net/manual/en/migration54.php)、 [5.5.x](http://php.net/manual/en/migration55.php)、 和 [5.6.x](http://php.net/manual/en/migration56.php)
 
 ## 关于：
 **版权声明**：原文来自 [PHP.net](http://php.net/manual/en/migration70.php)，此处仅作翻译。<br/>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ## 目录
 * [向后兼容性说明](./Backward-incompatible-changes.md)
 * [新的特性](./New-features.md)
-* [SAPI中的改动](./Sapi-changes.md)
-* [7.0.x版本开始停用的特性](./Deprecated.md)
+* [SAPI 中的改动](./Sapi-changes.md)
+* [7.0.x 版本开始停用的特性](./Deprecated.md)
 * [函数变更](./Changed-functions.md)
 * [新的函数](http://php.net/manual/en/migration70.new-functions.php)
 * [新的类与接口](http://php.net/manual/en/migration70.classes.php)
@@ -14,16 +14,16 @@
 ## PHP7 依然处于开发中
 ```PHP
 [警告] 
-    PHP7目前仍处于开发中并且短时间内还不能完成，本文中的一些新
+    PHP7 目前仍处于开发中并且短时间内还不能完成，本文中的一些新
     特性、修改还需等7.0版本正式发布后才能敲定（还有可能修改）。
     请你在将PHP7部署到线上生成环境之前再来确认下最新的变更是否
     对你的业务有影响。
 ```
-PHP7是一个全新的大版本，我们在努力让大家做到无缝的升级。这次版本变更专注在移除旧特性以保证语言的一致性。<br>
+PHP7 是一个全新的大版本，我们在努力让大家做到无缝的升级。这次版本变更专注在移除旧特性以保证语言的一致性。<br>
 这里有一些已经被确定的[不兼容](./Backward-incompatible-changes.md)和[新特性](./New-features.md)，请大家切换生产环境的PHP版本到PHP7之前，这些环节需要特别关注测试。<br>
-这里提供一些其他PHP版本的升级指南：[5.0.x](http://php.net/manual/en/migration5.php) [5.1.x](http://php.net/manual/en/migration51.php) [5.2.x](http://php.net/manual/en/migration52.php) [5.3.x](http://php.net/manual/en/migration53.php) [5.4.x](http://php.net/manual/en/migration54.php) [5.5.x](http://php.net/manual/en/migration55.php) 和 [5.6.x](http://php.net/manual/en/migration56.php)
+这里提供一些其他PHP版本的升级指南：[5.0.x](http://php.net/manual/en/migration5.php), [5.1.x](http://php.net/manual/en/migration51.php), [5.2.x](http://php.net/manual/en/migration52.php), [5.3.x](http://php.net/manual/en/migration53.php), [5.4.x](http://php.net/manual/en/migration54.php), [5.5.x](http://php.net/manual/en/migration55.php), 和 [5.6.x](http://php.net/manual/en/migration56.php)
 
 ## 关于：
-**版权声明**：原文来自[PHP.net](http://php.net/manual/en/migration70.php)，此处仅作翻译。<br/>
-**关于修正**：本人翻译能力有限，若有对原文理解不对或翻译不对的地方，欢迎push。
+**版权声明**：原文来自 [PHP.net](http://php.net/manual/en/migration70.php)，此处仅作翻译。<br/>
+**关于修正**：本人翻译能力有限，若有对原文理解不对或翻译不对的地方，欢迎 push。
 

--- a/Sapi-changes.md
+++ b/Sapi-changes.md
@@ -1,5 +1,5 @@
 # PHP 5.6.x 版本迁移至 PHP 7.0.x 版本
-## SAPI中的改动
+## SAPI 中的改动
 ### [FPM](http://php.net/manual/en/book.fpm.php)
 * Fixed bug #65933 (Cannot specify config lines longer than 1024 bytes).
 * Listen = port now listen on all addresses (IPv6 and IPv4-mapped).


### PR DESCRIPTION
- 按[中文文案排版指北](https://github.com/sparanoid/chinese-copywriting-guidelines)重新进行了中英文排版
- 部分格式修改及替换"得"
- 补充部分函数连接
